### PR TITLE
Fix success tracking with 1000-episode window

### DIFF
--- a/Assets/Scripts/PushBallAgent.cs
+++ b/Assets/Scripts/PushBallAgent.cs
@@ -72,7 +72,6 @@ public class PushBallAgent : Agent
         ball.rotation = startBallRot;
         
         previousBallToTargetDist = Vector3.Distance(ball.position, target.position);
-        SuccessTracker.totalEpisodes++;
         if (cornerDetector) cornerDetector.wallsTouching = 0;
     }
 
@@ -199,11 +198,12 @@ public class PushBallAgent : Agent
     public void NotifyBallEnteredGoal()
     {
         ballInTargetZone = true;
-        // SuccessTracker.successfulEpisodes++;
+        // SuccessTracker.RecordEpisodeResult(true);
         Recent.Add(1);
         AddReward(3f);
+        SuccessTracker.RecordEpisodeResult(true);
         EndEpisode();
-        // Debug.Log($"Success Rate: {(float)SuccessTracker.successfulEpisodes / SuccessTracker.totalEpisodes:P}");
+        // Debug.Log($"Success Rate: {SuccessTracker.GlobalSuccessRate:P}");
         if (Recent.IsFull)
         {
             var rate = Recent.GetRate();
@@ -217,6 +217,7 @@ public class PushBallAgent : Agent
     {
         Recent.Add(0);
         AddReward(penalty);
+        SuccessTracker.RecordEpisodeResult(false);
         EndEpisode();
     }
 
@@ -228,6 +229,7 @@ public class PushBallAgent : Agent
             AddReward(-Mathf.Clamp01(dist / 1.5f));
             AddReward(-1f);
         }
+        SuccessTracker.RecordEpisodeResult(ballInTargetZone);
         EndEpisode();
     }
     

--- a/Assets/Scripts/PushBallAgentRayCast.cs
+++ b/Assets/Scripts/PushBallAgentRayCast.cs
@@ -59,7 +59,6 @@ public class PushBallAgentRayCast : Agent
         ball.position = RandomSpawnPoint();
 
         previousBallToTargetDist = Vector3.Distance(ball.position, target.position);
-        SuccessTracker.totalEpisodes++;
         cornerDetector.wallsTouching = 0;
     }
 
@@ -172,14 +171,15 @@ public class PushBallAgentRayCast : Agent
     public void NotifyBallEnteredGoal()
     {
         ballInTargetZone = true;
-        SuccessTracker.successfulEpisodes++;
+        SuccessTracker.RecordEpisodeResult(true);
         AddReward(2f);
         EndEpisode();
-        Debug.Log($"Success Rate: {(float)SuccessTracker.successfulEpisodes / SuccessTracker.totalEpisodes:P}");
+        Debug.Log($"Success Rate: {SuccessTracker.GlobalSuccessRate:P}");
     }
 
     private void NotifyBallFailed(float penalty)
     {
+        SuccessTracker.RecordEpisodeResult(false);
         AddReward(penalty);
         EndEpisode();
     }
@@ -192,6 +192,7 @@ public class PushBallAgentRayCast : Agent
             AddReward(-Mathf.Clamp01(dist / 1.5f));
             AddReward(-1f);
         }
+        SuccessTracker.RecordEpisodeResult(ballInTargetZone);
         EndEpisode();
     }
     

--- a/Assets/Scripts/SuccessTracker.cs
+++ b/Assets/Scripts/SuccessTracker.cs
@@ -1,15 +1,20 @@
 public static class SuccessTracker
 {
-    public static int totalEpisodes = 0;
-    public static int successfulEpisodes = 0;
-
     private static readonly SuccessWindow Last1000 = new SuccessWindow(1000);
 
-    public static void RegisterSuccess() => Last1000.Add(1);
-    public static void AddEpisodes() => successfulEpisodes++;
+    public static int TotalEpisodes { get; private set; } = 0;
+    public static int SuccessfulEpisodes { get; private set; } = 0;
+
+    public static void RecordEpisodeResult(bool succeeded)
+    {
+        TotalEpisodes++;
+        if (succeeded) SuccessfulEpisodes++;
+
+        Last1000.Add(succeeded ? 1 : 0);
+    }
 
     public static float GlobalSuccessRate =>
-        totalEpisodes == 0 ? 0f : (float)successfulEpisodes / totalEpisodes * 100f;
+        TotalEpisodes == 0 ? 0f : (float)SuccessfulEpisodes / TotalEpisodes * 100f;
 
-    public static float RecentSuccessRate => Last1000.GetRate();
+    public static float RecentSuccessRate => Last1000.Length == 0 ? 0f : Last1000.GetRate();
 }

--- a/Assets/Scripts/SuccessWindow.cs
+++ b/Assets/Scripts/SuccessWindow.cs
@@ -20,6 +20,8 @@ public class SuccessWindow
 
     public float GetRate()
     {
+        if (count == 0) return 0f;
+
         int sum = 0;
         for (int i = 0; i < count; i++)
             sum += buffer[i];


### PR DESCRIPTION
## Summary
- record episode outcomes in SuccessTracker and compute rates over the latest 1,000 episodes
- ensure agents report successes and failures when episodes end
- guard recent success rate calculation against empty windows

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b32bd18a0832099cc345cbd4c1dab)