### PR TITLE
Fix target color change to only affect colliding zone

### DIFF
--- a/Assets/Scripts/Box.cs
+++ b/Assets/Scripts/Box.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 public class Box : MonoBehaviour
 {
     public PushBallAgent agent;
-    public static event Action OnBoxReachedGoal;
+    public static event Action<Collider> OnBoxReachedGoal;
     
     
 
@@ -13,7 +13,7 @@ public class Box : MonoBehaviour
         if (other.CompareTag("TargetZone"))
         {
             //Debug.Log("Ball entered TargetZone");
-            OnBoxReachedGoal?.Invoke();
+            OnBoxReachedGoal?.Invoke(other);
             agent.NotifyBallEnteredGoal();
         }
     }

--- a/Assets/Scripts/ColourChange.cs
+++ b/Assets/Scripts/ColourChange.cs
@@ -7,13 +7,15 @@ public class ColourChange : MonoBehaviour
     public Material defMat;
 
     private Renderer rend;
+    private Collider targetCollider;
 
     private void Awake()
     {
         rend = GetComponent<Renderer>();
         defMat = rend.material;
+        targetCollider = GetComponent<Collider>();
     }
-    
+
     private void OnEnable()
     {
         Box.OnBoxReachedGoal += ChangeMaterialTemporary;
@@ -24,8 +26,13 @@ public class ColourChange : MonoBehaviour
         Box.OnBoxReachedGoal -= ChangeMaterialTemporary;
     }
 
-    private void ChangeMaterialTemporary()
+    private void ChangeMaterialTemporary(Collider target)
     {
+        if (target != targetCollider)
+        {
+            return;
+        }
+
         StopAllCoroutines(); // In case it's already running
         StartCoroutine(ChangeRoutine());
     }


### PR DESCRIPTION
## Summary
- update target color change logic to identify which collider triggered the goal event
- limit color change coroutine to the target collider that received the ball collision

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692edaf847a4832081e58c0e61cdc725)